### PR TITLE
Added error handling on empty inputs

### DIFF
--- a/app/src/pages/createcharge.tsx
+++ b/app/src/pages/createcharge.tsx
@@ -18,6 +18,7 @@ const CreateChargePage: NextPage = () => {
     const [billAmount, setBillAmount] = useState<number>(0);
     const [billId, setBillId] = useState<string>("");
     const [dueDate, setDueDate] = useState<string>("");
+    const [category, setCategory] = useState<string>("");
 
     const selectedHome = useHomeContext((s) => s.selectedHome);
     const router = useRouter();
@@ -44,7 +45,8 @@ const CreateChargePage: NextPage = () => {
         const billName = form.elements["name"].value;
         const billAmount = form.elements["amount"].value;
         const dueDate = form.elements["dueDate"].value;
-        if(billName.length < 1 || billAmount < .01) {
+        const category = form.elements["category"].value;
+        if(billName.length < 1 || billAmount < .01 || category < 1) {
             setError("The form elements cannot be empty or negative!");
             return;
         }
@@ -52,6 +54,7 @@ const CreateChargePage: NextPage = () => {
         setBillName(billName);
         setBillAmount(billAmount);
         setDueDate(dueDate);
+        setCategory(category);
 
         // check which home occupants to charge
         let checkedId = 0;

--- a/app/src/pages/createcharge.tsx
+++ b/app/src/pages/createcharge.tsx
@@ -46,15 +46,26 @@ const CreateChargePage: NextPage = () => {
         const billAmount = form.elements["amount"].value;
         const dueDate = form.elements["dueDate"].value;
         const category = form.elements["category"].value;
-        if(billName.length < 1 || billAmount < 0.01 || category < 1) {
-            setError("The form elements cannot be empty or negative!");
+
+        if(billName.trim().length < 1) {
+            setError("The charge must have a name, it cannot be empty.");
             return;
+        }
+
+        if(billAmount < 0.01) {
+            setError("The bill amount must be greater than 0.01");
+            return;
+        }
+
+        if(category.trim().length < 1) {
+            setCategory("Other");
+        }else{
+            setCategory(category);
         }
 
         setBillName(billName);
         setBillAmount(billAmount);
         setDueDate(dueDate);
-        setCategory(category);
 
         // check which home occupants to charge
         let checkedId = 0;

--- a/app/src/pages/createcharge.tsx
+++ b/app/src/pages/createcharge.tsx
@@ -86,7 +86,7 @@ const CreateChargePage: NextPage = () => {
           setSplittingPage(true);
           setError(null);
         } else {
-            setError("You must have exactly only occupant as payer for a charge.");
+            setError("You must have exactly one occupant as payer for a charge.");
             return;
         }
     };

--- a/app/src/pages/createcharge.tsx
+++ b/app/src/pages/createcharge.tsx
@@ -46,7 +46,7 @@ const CreateChargePage: NextPage = () => {
         const billAmount = form.elements["amount"].value;
         const dueDate = form.elements["dueDate"].value;
         const category = form.elements["category"].value;
-        if(billName.length < 1 || billAmount < .01 || category < 1) {
+        if(billName.length < 1 || billAmount < 0.01 || category < 1) {
             setError("The form elements cannot be empty or negative!");
             return;
         }

--- a/app/src/pages/createcharge.tsx
+++ b/app/src/pages/createcharge.tsx
@@ -44,6 +44,10 @@ const CreateChargePage: NextPage = () => {
         const billName = form.elements["name"].value;
         const billAmount = form.elements["amount"].value;
         const dueDate = form.elements["dueDate"].value;
+        if(billName.length < 1 || billAmount < .01) {
+            setError("The form elements cannot be empty or negative!");
+            return;
+        }
 
         setBillName(billName);
         setBillAmount(billAmount);
@@ -67,6 +71,9 @@ const CreateChargePage: NextPage = () => {
         if(checkedId === 1){
           setSplittingPage(true);
           setError(null);
+        } else {
+            setError("You must have exactly only occupant as payer for a charge.");
+            return;
         }
     };
 
@@ -155,7 +162,10 @@ const CreateChargePage: NextPage = () => {
                               {occupants.data &&
                                   occupants.data.map((occupant) => {
                                       return (
-                                          <div key={occupant.user.id}>
+                                          <div 
+                                            key={occupant.user.id}
+                                            className="sm:bg-transparent md:bg-slate-600 items-center mx-10 my-10 rounded-xl flex flex-col sm:text-black md:text-dorian text-base justify-between"
+                                            >
                                               <div className="rounded-full bg-evergreen-80 w-24 h-24 flex flex-col items-center justify-center">
                                                   {occupant.user.image ? (
                                                       <Image
@@ -183,7 +193,7 @@ const CreateChargePage: NextPage = () => {
                                                       </p>
                                                   )}
                                               </div>
-                                              <div className="text-dorian">
+                                              <div className="text-dorian mt-10">
                                                   {occupant.user.name}
                                               </div>
                                               <MoneyFieldInput

--- a/app/src/pages/createhome.tsx
+++ b/app/src/pages/createhome.tsx
@@ -35,8 +35,12 @@ const CreationPage: NextPage = () => {
 
         const nameVal = form.elements["name"].value;
         const addressVal = form.elements["address"].value;
-        if(nameVal.length < 1 || addressVal.length < 1) {
-            setError("The input fields cannot be empty!");
+        if(nameVal.trim().length < 1) {
+            setError("The home must have a name, it cannot be empty.");
+            return;
+        }
+        if(addressVal.trim().length < 1) {
+            setError("The home must have an address, it cannot be empty.");
             return;
         }
 

--- a/app/src/pages/createhome.tsx
+++ b/app/src/pages/createhome.tsx
@@ -33,6 +33,13 @@ const CreationPage: NextPage = () => {
         event.preventDefault();
         const form = event.target as HTMLFormElement;
 
+        const nameVal = form.elements["name"].value;
+        const addressVal = form.elements["address"].value;
+        if(nameVal.length < 1 || addressVal.length < 1) {
+            setError("The input fields cannot be empty!");
+            return;
+        }
+
         const fileList = fileRef.current?.files
         if(!fileList){
             return;
@@ -59,8 +66,8 @@ const CreationPage: NextPage = () => {
         
         await createHome.mutateAsync({
             image: key,
-            name: form.elements["name"].value,
-            address: form.elements["address"].value,
+            name: nameVal,
+            address: addressVal,
         });
     };
 


### PR DESCRIPTION
## Jira Ticket:
RBH-60-Home-CRUD-and-billing-errors-handling

## Description of Work
I added checks on the input fields to yell at the user if they try and input with empty inputs

## Acceptance Criteria

- Not allow Users to create charges or homes without names or descriptions.

## How to Test

- Launch webapp, try and create a home or charge with no or only some input fields filled out.

### List of Changes:

- Catches on createhome that check the input values
- Catches on createcharge that check the input values

### Screenshots

| Image | Description |
| ----- | ----------- |
| ![image](https://user-images.githubusercontent.com/73263545/229961252-855137af-4c42-43fb-b2fd-cd707696317d.png)| Error when trying to create a home with no input fields filled out.|
| ![image](https://user-images.githubusercontent.com/73263545/229961350-e8a6eea1-151c-4cfe-af03-715b328e573e.png)| Error when trying to create a charge with no input fields filled out.|
