### PR TITLE
fix default selected home from localStorage or query

### DIFF
--- a/app/src/stores/HomeStore.tsx
+++ b/app/src/stores/HomeStore.tsx
@@ -61,8 +61,9 @@ const createHomeStore = (initState?: Partial<HomeState>) =>
             const refetch = get().refetch;
             const result = await refetch();
             if (!result?.data) return;
-            if (
-                !localStorage.getItem("selectedHome") &&
+            if(localStorage.getItem("selectedHome"))
+                set({ selectedHome: localStorage.getItem("selectedHome") });
+            else if (
                 !get().selectedHome &&
                 result.data.length > 0 &&
                 result.data[0]
@@ -91,7 +92,9 @@ export const HomeProvider = ({ children, ...props}: HomeProviderProps) => {
         getHomes().then(homes => {
             if(!homes.data) return;
             storeRef.current?.getState().setHomes(homes.data);
-            if(!localStorage.getItem('selectedHome') && homes.data.length > 0 && homes.data[0])
+            if(localStorage.getItem('selectedHome'))
+                storeRef.current?.getState().setSelectedHome(localStorage.getItem('selectedHome'));
+            else if(homes.data.length > 0 && homes.data[0])
                 storeRef.current?.getState().setSelectedHome(homes.data[0].id);
         })
     }, [session.data, getHomes]);


### PR DESCRIPTION
## Jira Ticket:
[RBH-59](https://roommatebudgethelper.atlassian.net/jira/software/projects/RBH/boards/1?selectedIssue=RBH-59)
## Description of Work
Fixed state management to get the default selected home from localStorage if there otherwise first home in query.
## Acceptance Criteria

- Verify that if user has homes, one is selected always by default
- Verify that if removing localStorage, on refresh the default home is the first one in the list of homes
- Verify on losing focus of the page (Minimize, etc.) that the home will stay the same.

## How to Test

- Manual Testing
- Cypress Tests

### List of Changes:

- Home is selected from localStorage as default if exists
- Otherwise default is set as first in list returned by query

### Screenshots

| Image | Description |
| ![image](https://user-images.githubusercontent.com/56805345/230442571-08bddeb9-b723-431a-9998-7e389d002f0a.png) | Home Id Stored in Local Storage |
