### PR TITLE
home maintenance error handling

### DIFF
--- a/app/src/pages/homes.tsx
+++ b/app/src/pages/homes.tsx
@@ -75,10 +75,11 @@ const HomesPage: NextPage = () => {
 
     const handleLeave = async () => {
         setLeaveModalOpen(false);
-        if(selectedHome !== null) {
+        if(selectedHome !== null && session?.user?.id) {
             const leaveCheck = await leaveHome.mutateAsync({homeId: selectedHome});
             if(leaveCheck === "bad"){
-                setModalError("You are the only Owner. You cannot leave the home unless you delete it or pass on Owner permission!")
+                setModalError("You are the only Owner. You cannot leave the home unless you delete it or pass on Owner permission!");
+                return;
             }
         }
         await refetchHomes();
@@ -117,12 +118,16 @@ const HomesPage: NextPage = () => {
                 permissions.push(input.value);
             }
         }
-       await editPermissions.mutateAsync({
+       const permissionCheck = await editPermissions.mutateAsync({
             user: form.elements["User"].value as string,
             homeId: selectedHome,
             permissions,
         });
-        setEditPermissionsModalOpen(false);
+        if(permissionCheck === "bad") {
+            setModalError("You cannot change your own Permissions!");
+        } else {
+            setEditPermissionsModalOpen(false);
+        }
     }
 
     const handleInvite = async (event: React.FormEvent<HTMLFormElement>) => {

--- a/app/src/pages/homes.tsx
+++ b/app/src/pages/homes.tsx
@@ -18,7 +18,7 @@ import { useSession } from "next-auth/react";
 
 const HomesPage: NextPage = () => {
     const { data: session } = useSession();
-    const [error, setError] = useState<string | null>(null);
+    const [modalError, setModalError] = useState<string | null>(null);
     const [isMenuOpen, setMenuOpen] = useState<boolean>(false);
     const [isDeleteModalOpen, setDeleteModalOpen] = useState<boolean>(false);
     const [isLeaveModalOpen, setLeaveModalOpen] = useState<boolean>(false);
@@ -61,7 +61,10 @@ const HomesPage: NextPage = () => {
         getOccupants();
     }, [selectedHome, getPermissions, getOccupants]);
 
-    const handleToggleModal = (setterFunction: React.Dispatch<React.SetStateAction<boolean>>) => () => setterFunction(state => !state);
+    const handleToggleModal = (setterFunction: React.Dispatch<React.SetStateAction<boolean>>) => () => {
+        setterFunction(state => !state);
+        setModalError(null);
+    }
     
     const handleDelete = async () => {
         setDeleteModalOpen(false);
@@ -117,11 +120,16 @@ const HomesPage: NextPage = () => {
         event.preventDefault();
         const form = (event.target as HTMLFormElement);
         if(!selectedHome) return;
-        await inviteRoommate.mutateAsync({
+        const checkInvite = await inviteRoommate.mutateAsync({
             homeId: selectedHome,
             email: form.elements["email"].value,
         });
-        setInviteModalOpen(false);
+        if(checkInvite === "bad") {
+            setModalError("The invite failed.\n Make sure the user is not already invited to the home,\n in the home or that you did not invite yourself!");
+            return;
+        } else {
+            setInviteModalOpen(false);
+        }
     }
 
     return (
@@ -166,7 +174,6 @@ const HomesPage: NextPage = () => {
                                 </div>
                             </div>
                         </div>
-                        {error&&<p className="text-xl font-light text-red-600">{error}</p>}
                     </div> :
                     <div className="form-area flex flex-col justify-between items-center">
                         <div className="p-5">
@@ -186,7 +193,6 @@ const HomesPage: NextPage = () => {
                             Feel free to create more homes using the plus button, or
                             contact your home creator to invite you!
                         </div>
-                        {error&&<p className="text-xl font-light text-red-600">{error}</p>}
                     </div>}
                 </div>              
             </div>
@@ -236,6 +242,7 @@ const HomesPage: NextPage = () => {
                         </select>) : (<p className="text-2xl font-bold">You are the only occupant in this home</p>)
                     }
                     </div>
+                    {modalError&&<p className="text-xl font-light text-red-600">{modalError}</p>}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button classNames="bg-red-600" onClick={handleToggleModal(setRemovalModalOpen)} value="Cancel"/>
@@ -265,6 +272,7 @@ const HomesPage: NextPage = () => {
                             {permission}
                         </div>
                     ))}
+                    {modalError&&<p className="text-xl font-light text-red-600">{modalError}</p>}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button classNames="bg-red-600" onClick={handleToggleModal(setEditPermissionsModalOpen)} value="Cancel"/>
@@ -281,6 +289,7 @@ const HomesPage: NextPage = () => {
                         <FieldInput
                         name="email"
                         placeholder="email"/>
+                    {modalError&&<p className="text-xl font-light text-red-600">{modalError}</p>}
                     </Modal.Body>
                     <Modal.Footer>
                         <Button classNames="bg-red-600" onClick={handleToggleModal(setInviteModalOpen)} value="Cancel"/>

--- a/app/src/pages/homes.tsx
+++ b/app/src/pages/homes.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import FieldInput from "@components/fieldinput";
 import { Permission } from "types/permissions";
 import { useSession } from "next-auth/react";
+import { z } from "zod";
 
 
 const HomesPage: NextPage = () => {
@@ -134,13 +135,14 @@ const HomesPage: NextPage = () => {
         event.preventDefault();
         const form = (event.target as HTMLFormElement);
         if(!selectedHome) return;
-        if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(form.email.value)) {
+        const emailSchema = z.string().email().safeParse(form.email.value);
+        if (!emailSchema.success) {
             setModalError("This is not a valid email!");
             return;
         }
         const checkInvite = await inviteRoommate.mutateAsync({
             homeId: selectedHome,
-            email: form.email.value,
+            email: emailSchema.data,
         });
         if(checkInvite === "bad") {
             setModalError("The invite failed.\n Make sure the user is not already invited to the home,\n in the home or that you did not invite yourself!");

--- a/app/src/pages/homes.tsx
+++ b/app/src/pages/homes.tsx
@@ -90,8 +90,8 @@ const HomesPage: NextPage = () => {
         event.preventDefault();
         if(!selectedHome) return;
         const form = (event.target as HTMLFormElement);
-        if(!form.elements["User"]) return;
-        const formUserId = form.elements["User"].value as string;
+        if(!form.User) return;
+        const formUserId = form.User.value as string;
 
         const removeCheck = await removeUser.mutateAsync({
             homeId: selectedHome,
@@ -111,7 +111,7 @@ const HomesPage: NextPage = () => {
         }
 
         const form = (event.target as HTMLFormElement);
-        const permissionsInputs = form.elements["Permissions"].entries();
+        const permissionsInputs = form.Permissions.entries();
         const permissions: Permission[] = []
         for(const [_, input] of permissionsInputs){
             if(input.checked){
@@ -119,7 +119,7 @@ const HomesPage: NextPage = () => {
             }
         }
        const permissionCheck = await editPermissions.mutateAsync({
-            user: form.elements["User"].value as string,
+            user: form.User.value as string,
             homeId: selectedHome,
             permissions,
         });
@@ -134,13 +134,13 @@ const HomesPage: NextPage = () => {
         event.preventDefault();
         const form = (event.target as HTMLFormElement);
         if(!selectedHome) return;
-        if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(form.elements["email"].value)) {
+        if (!/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(form.email.value)) {
             setModalError("This is not a valid email!");
             return;
         }
         const checkInvite = await inviteRoommate.mutateAsync({
             homeId: selectedHome,
-            email: form.elements["email"].value,
+            email: form.email.value,
         });
         if(checkInvite === "bad") {
             setModalError("The invite failed.\n Make sure the user is not already invited to the home,\n in the home or that you did not invite yourself!");
@@ -249,7 +249,7 @@ const HomesPage: NextPage = () => {
                         (<select name="User">
                             {occupants?.map(occupant => {
                                 // get the current user id and compare it to the occupant id
-                                if(session && session.user && occupant.user.id !== session.user.id){
+                                if(occupant?.user?.id !== session?.user?.id){
                                     return (
                                         <option
                                             key={occupant.user.id}

--- a/app/src/server/db/HomeService.ts
+++ b/app/src/server/db/HomeService.ts
@@ -1,4 +1,3 @@
-import { Permission } from "@aws-sdk/client-s3";
 import { PrismaClient } from "@prisma/client";
 
 export const canUserViewHome = async (id: string, homeId: string, db: PrismaClient) => {

--- a/app/src/server/db/HomeService.ts
+++ b/app/src/server/db/HomeService.ts
@@ -24,18 +24,6 @@ export const userIsInvited = async (email: string, homeId: string, db: PrismaCli
     }))
 }
 
-export const userIsInHome = async (userId: string, homeId: string, db: PrismaClient) => {
-    return !!(await db.occupies.findFirst({
-        select: {
-            homeId: true,
-        },
-        where: {
-            homeId: homeId,
-            userId: userId,
-        }
-    }))
-}
-
 export const moreThanOneOwner = async (userId:string, homeId: string, db: PrismaClient) => {
     const homeOwners = await db.permission.findMany({
         select: {

--- a/app/src/server/db/HomeService.ts
+++ b/app/src/server/db/HomeService.ts
@@ -11,3 +11,27 @@ export const canUserViewHome = async (id: string, homeId: string, db: PrismaClie
         }
     }));
 }
+
+export const userIsInvited = async (email: string, homeId: string, db: PrismaClient) => {
+    return !!(await db.invitation.findFirst({
+        select: {
+            homeId: true,
+        },
+        where: {
+            homeId: homeId,
+            email: email
+        }
+    }))
+}
+
+export const userIsInHome = async (email: string, homeId: string, db: PrismaClient) => {
+    return !!(await db.occupies.findFirst({
+        select: {
+            homeId: true,
+        },
+        where: {
+            homeId: homeId,
+            userId: email,
+        }
+    }))
+}

--- a/app/src/server/db/HomeService.ts
+++ b/app/src/server/db/HomeService.ts
@@ -1,3 +1,4 @@
+import { Permission } from "@aws-sdk/client-s3";
 import { PrismaClient } from "@prisma/client";
 
 export const canUserViewHome = async (id: string, homeId: string, db: PrismaClient) => {
@@ -24,14 +25,29 @@ export const userIsInvited = async (email: string, homeId: string, db: PrismaCli
     }))
 }
 
-export const userIsInHome = async (email: string, homeId: string, db: PrismaClient) => {
+export const userIsInHome = async (userId: string, homeId: string, db: PrismaClient) => {
     return !!(await db.occupies.findFirst({
         select: {
             homeId: true,
         },
         where: {
             homeId: homeId,
-            userId: email,
+            userId: userId,
         }
     }))
+}
+
+export const moreThanOneOwner = async (userId:string, homeId: string, db: PrismaClient) => {
+    const homeOwners = await db.permission.findMany({
+        select: {
+            occupiesUserId: true
+        },
+        where: {
+            occupiesHomeId: homeId,
+            name: "OWNER"
+        }
+    })
+    if(homeOwners.length > 1) return true; 
+    if(homeOwners[0]?.occupiesUserId !== userId) return true;
+    return false;
 }

--- a/app/src/server/db/UserService.ts
+++ b/app/src/server/db/UserService.ts
@@ -13,6 +13,17 @@ export const getUserPermissions = async (user: string, homeId: string, db: Prism
     }))?.permissions;
 }
 
+export const getUserByEmail = async (email: string, db: PrismaClient) => {
+    return (await db.user.findFirst({
+        select: {
+            id: true
+        },
+        where: {
+            email: email
+        }
+    }))
+}
+
 export const hasPermission = async (user: string, homeId: string, permission: Permission, db: PrismaClient) => {
     const conditions = [
         {
@@ -35,4 +46,19 @@ export const hasPermission = async (user: string, homeId: string, permission: Pe
             occupiesHomeId: homeId,
         }
     }))
+}
+
+export const isOwner = async (userId:string, homeId: string, db: PrismaClient) => {
+    const homeOwners = await db.permission.findFirst({
+        select: {
+            occupiesUserId: true
+        },
+        where: {
+            occupiesHomeId: homeId,
+            name: "OWNER",
+            occupiesUserId: userId
+        }
+    })
+    if(homeOwners) return true;
+    return false;
 }

--- a/app/src/server/router/homes.ts
+++ b/app/src/server/router/homes.ts
@@ -105,6 +105,11 @@ export const homesRouter = createProtectedRouter()
                     homeId: input.id,
                 }
             }); 
+            await ctx.prisma.permission.deleteMany({
+                where: {
+                    occupiesHomeId: input.id,
+                }
+            })
             return await ctx.prisma.home.delete({
                 where: {
                     id: input.id,

--- a/app/src/server/router/invitation.ts
+++ b/app/src/server/router/invitation.ts
@@ -1,5 +1,5 @@
 import { Permission } from "../../types/permissions";
-import { canUserViewHome, userIsInvited, userIsInHome } from "../db/HomeService";
+import { canUserViewHome, userIsInvited } from "../db/HomeService";
 import { hasPermission, getUserByEmail } from "../db/UserService";
 import { sendEmail } from "../services/email/invitation";
 import { z } from "zod";
@@ -19,7 +19,7 @@ export const invitationRouter = createProtectedRouter()
            !(await canUserViewHome(ctx.session.user.id,input.homeId, ctx.prisma)) ||
            await userIsInvited(input.email, input.homeId, ctx.prisma) ||
            !userId ||
-           await userIsInHome(userId.id, input.homeId, ctx.prisma))
+           await canUserViewHome(userId.id, input.homeId, ctx.prisma))
                 return "bad";
         const home = await ctx.prisma.home.findFirst({
             select: {

--- a/app/src/server/router/occupies.ts
+++ b/app/src/server/router/occupies.ts
@@ -29,6 +29,12 @@ export const occupiesRouter = createProtectedRouter()
             if(!(await moreThanOneOwner(ctx.session.user.id, input.homeId, ctx.prisma))) {
                 return "bad";
             }
+            await ctx.prisma.permission.deleteMany({
+                where: {
+                    occupiesHomeId: input.homeId,
+                    occupiesUserId: ctx.session.user.id
+                }
+            })
             return await ctx.prisma.occupies.delete({
                 where: {
                     userId_homeId: {
@@ -51,6 +57,12 @@ export const occupiesRouter = createProtectedRouter()
                 !(await moreThanOneOwner(input.userId, input.homeId, ctx.prisma)))) {
                 return "bad";
             }
+            await ctx.prisma.permission.deleteMany({
+                where: {
+                    occupiesHomeId: input.homeId,
+                    occupiesUserId: input.userId
+                }
+            })
             return await ctx.prisma.occupies.delete({
                 where: {
                     userId_homeId: {
@@ -102,8 +114,9 @@ export const occupiesRouter = createProtectedRouter()
         }),
         async resolve({ ctx, input }){
             if(!(await canUserViewHome(ctx.session.user.id, input.homeId, ctx.prisma)) ||
-               !(await hasPermission(ctx.session.user.id, input.homeId, Permission.Owner, ctx.prisma)))
-               return; 
+               !(await hasPermission(ctx.session.user.id, input.homeId, Permission.Owner, ctx.prisma)) ||
+               (await ctx.session.user.id === input.user))
+               return "bad"; 
             await ctx.prisma.permission.deleteMany({
                 where: {
                    occupiesHomeId: input.homeId,

--- a/app/src/server/router/occupies.ts
+++ b/app/src/server/router/occupies.ts
@@ -2,7 +2,7 @@ import { createProtectedRouter } from "./context";
 import { z } from "zod";
 import { getUserPermissions, hasPermission, isOwner } from "../db/UserService";
 import { Permission } from "../../types/permissions";
-import { canUserViewHome, moreThanOneOwner, userIsInHome } from "../db/HomeService";
+import { canUserViewHome, moreThanOneOwner } from "../db/HomeService";
 import { getSignedImage } from "./image-upload";
 
 export const occupiesRouter = createProtectedRouter()
@@ -53,7 +53,7 @@ export const occupiesRouter = createProtectedRouter()
         }),
         async resolve({ ctx, input }) {
             if (!(await hasPermission(ctx.session.user.id, input.homeId, Permission.Owner, ctx.prisma)) ||
-                !(await userIsInHome(input.userId, input.homeId, ctx.prisma)) ||
+                !(await canUserViewHome(input.userId, input.homeId, ctx.prisma)) ||
                 ((await isOwner(input.userId, input.homeId, ctx.prisma)) && 
                 !(await moreThanOneOwner(input.userId, input.homeId, ctx.prisma)))) {
                 return "bad";


### PR DESCRIPTION
## Jira Ticket:
RBH 65 Home Maintenance Error Handling
## Description of Work
In this PR, I added code to the modals of the Home Maintenance to stop user errors on those modals.
## Acceptance Criteria

- User cannot cause issues in Modals

## How to Test

- Manual test by trying to do things the modal shouldn't cover.

### List of Changes:

- Invitations stop the user from inviting someone twice, inviting people in the house already, inputting a non-email, and from inviting themselves.
- Edit permissions does not allow a User to change their own permissions, just other peoples.
- Remove Roommate will not allow a person to be removed if they are the only owner in a house
- Leave house will not allow someone to leave if they are the only user with owner role.
- Whenever a person leaves a house or deletes one, all permissions tied to those people are removed.

### Screenshots

| Image | Description |
| ----- | ----------- |
| ![image](https://user-images.githubusercontent.com/73263545/234472399-6e9ec0bc-2589-4bac-a73f-50374bcaeee2.png)|User tried inviting someone twice|
|![image](https://user-images.githubusercontent.com/73263545/234472526-e5f22950-c482-4bdc-bdb5-96bb2b634253.png)|User tried to remove the only Owner|
|![image](https://user-images.githubusercontent.com/73263545/234472597-07a0213f-d4fb-4b96-b070-fbfced43e5b4.png)|User tried changing their own permissions|